### PR TITLE
Fix train-push logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+data_cache/
+history/
 develop-eggs/
 dist/
 downloads/

--- a/app/model_manager.py
+++ b/app/model_manager.py
@@ -1,3 +1,5 @@
+import glob
+import logging
 import os
 import pickle
 
@@ -7,68 +9,58 @@ from app.models.factory import get_model
 from app.transfer_learning import load_training_metadata
 
 ARTIFACTS_ROOT = os.getenv("MODEL_ARTIFACTS_DIR", "saved_models")
-DEFAULT_MODEL_VERSION = os.getenv("MODEL_VERSION", "v1")
 
-# Конфигурация по тикерам с именами файлов и параметрами по умолчанию
-TICKER_CONFIGS = {
-    "SBER": {
-        "default_factory": "lstm",
-        "model_file": "SBER_model.pth",
-        "scaler_x": "SBER_scaler_X.pkl",
-        "scaler_y": "SBER_scaler_y.pkl",
-        "params": {
-            "seq_length": 20,
-            "num_features": 18,
-            "output_dim": 1,
-            "lstm_units": 240,
-            "fc_units": 127,
-            "dropout_rate": 0.1335,
-        },
-    },
-    "GAZP": {
-        "default_factory": "tcn",
-        "model_file": "GAZP_model.pth",
-        "scaler_x": "GAZP_scaler_X.pkl",
-        "scaler_y": "GAZP_scaler_y.pkl",
-        "params": {
-            "num_features": 18,
-            "num_channels": [64, 128, 256, 512],
-            "kernel_size": 5,
-            "dropout": 0.28,
-            "fc_units": 30,
-        },
-    },
-    "ROSN": {
-        "default_factory": "tft",
-        "model_file": "ROSN_model.pth",
-        "scaler_x": "ROSN_scaler_X.pkl",
-        "scaler_y": "ROSN_scaler_y.pkl",
-        "params": {
-            "seq_length": 15,
-            "num_features": 18,
-            "d_model": 32,
-            "n_heads": 4,
-            "n_layers": 2,
-            "d_ff": 384,
-            "dropout": 0.09031434953930437,
-        },
-    },
-}
+# Настраиваем логгер модуля
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    fmt = logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
+    handler.setFormatter(fmt)
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 def load_models():
+    """
+    Загружает все модели, которые есть в training_metadata.pkl.
+    Для каждого <TICKER> из метаданных ищем артефакты в saved_models/<version>/:
+      - веса: либо '<ticker>_best.pth', либо '<ticker>_model.pth'
+      - скейлеры: '<ticker>_scaler_X.pkl', '<ticker>_scaler_y.pkl'
+    Логирует по мере загрузки.
+    """
     models = {}
     metadata = load_training_metadata()
-    for ticker, cfg in TICKER_CONFIGS.items():
-        version = metadata.get(f"{ticker}_model_version", DEFAULT_MODEL_VERSION)
-        factory_key = metadata.get(f"{ticker}_factory_key", cfg["default_factory"])
-        params = metadata.get(f"{ticker}_model_params", cfg["params"])
+
+    for key, version in metadata.items():
+        if not key.endswith("_model_version"):
+            continue
+        ticker = key[: -len("_model_version")]
+        factory_key = metadata.get(f"{ticker}_factory_key")
+        params = metadata.get(f"{ticker}_model_params")
+
+        if factory_key is None or params is None:
+            logger.warning(f"Пропускаем {ticker}: неполные метаданные")
+            continue
 
         model_dir = os.path.join(ARTIFACTS_ROOT, version)
-        path_model = os.path.join(model_dir, cfg["model_file"])
-        path_sx = os.path.join(model_dir, cfg["scaler_x"])
-        path_sy = os.path.join(model_dir, cfg["scaler_y"])
-        if not all(os.path.exists(p) for p in (path_model, path_sx, path_sy)):
+        if not os.path.isdir(model_dir):
+            logger.warning(f"Директория не найдена: {model_dir}")
+            continue
+
+        # ищем файл весов
+        matches = glob.glob(os.path.join(model_dir, f"{ticker}_best.pth")) + glob.glob(
+            os.path.join(model_dir, f"{ticker}_model.pth")
+        )
+        if not matches:
+            logger.warning(f"Весов для {ticker}@{version} не найдено")
+            continue
+        path_model = matches[0]
+
+        # пути к скейлерам
+        path_sx = os.path.join(model_dir, f"{ticker}_scaler_X.pkl")
+        path_sy = os.path.join(model_dir, f"{ticker}_scaler_y.pkl")
+        if not (os.path.exists(path_sx) and os.path.exists(path_sy)):
+            logger.warning(f"Скейлеры для {ticker}@{version} не найдены")
             continue
 
         try:
@@ -77,7 +69,7 @@ def load_models():
             model.load_state_dict(state)
             model.eval()
         except Exception as e:
-            print(f"[ERROR] Failed to load model for {ticker}: {e}")
+            logger.error(f"Не удалось загрузить {ticker}@{version}: {e}")
             continue
 
         with open(path_sx, "rb") as f:
@@ -91,8 +83,14 @@ def load_models():
             "scaler_y": scaler_y,
             "seq_length": params.get("seq_length"),
             "model_version": version,
+            "factory_key": factory_key,
+            "model_params": params,
         }
+        logger.info(f"Загружена модель {ticker}@{version}")
 
     if not models:
+        logger.error("Не загружено ни одной модели")
         raise RuntimeError("No models loaded")
+
+    logger.info(f"Всего загружено моделей: {len(models)} ({', '.join(models.keys())})")
     return models

--- a/app/models/attention_lstm.py
+++ b/app/models/attention_lstm.py
@@ -35,5 +35,22 @@ class LSTMModel(nn.Module):
         return self.fc2(self.dropout(h))
 
 
-def build_model(**kwargs):
-    return LSTMModel(**kwargs)
+def build_model(
+    seq_length: int,
+    num_features: int,
+    output_dim: int,
+    lstm_units: int,
+    fc_units: int,
+    dropout_rate: float,
+) -> nn.Module:
+    """
+    Фабричная функция для создания LSTMModel.
+    """
+    return LSTMModel(
+        seq_length=seq_length,
+        num_features=num_features,
+        output_dim=output_dim,
+        lstm_units=lstm_units,
+        fc_units=fc_units,
+        dropout_rate=dropout_rate,
+    )

--- a/app/models/tcn.py
+++ b/app/models/tcn.py
@@ -105,5 +105,22 @@ class TCNModel(nn.Module):
         return self.out(h)
 
 
-def build_model(**kwargs):
-    return TCNModel(**kwargs)
+def build_model(
+    seq_length: int,
+    num_features: int,
+    num_channels: list[int],
+    kernel_size: int,
+    fc_units: int,
+    dropout: float,
+) -> nn.Module:
+    """
+    Фабричная функция для создания TCNModel.
+    """
+    return TCNModel(
+        seq_length=seq_length,
+        num_features=num_features,
+        num_channels=num_channels,
+        kernel_size=kernel_size,
+        fc_units=fc_units,
+        dropout=dropout,
+    )

--- a/app/optimization.py
+++ b/app/optimization.py
@@ -1,3 +1,6 @@
+import ast
+import inspect
+import logging
 from importlib import import_module
 
 import optuna
@@ -6,38 +9,56 @@ from omegaconf import DictConfig, OmegaConf
 
 from app.models.factory import AVAILABLE
 
+log = logging.getLogger(__name__)
+
 
 def build_model_and_lr(model_name: str, model_cfg: dict, opt_cfg: DictConfig, trial):
     # Learning rate
     lr = trial.suggest_float("learning_rate", *opt_cfg.lr_range, log=True)
 
     # Подготовка параметров модели
-    # Конвертируем search_space в обычный dict
     search_space = OmegaConf.to_container(opt_cfg.search_space, resolve=True)
     params = {}
     fixed_keys = {"seq_length", "num_features", "output_dim"}
+
     for key, base_val in model_cfg.items():
         if key in fixed_keys:
             params[key] = base_val
         elif key in search_space:
-            # выбираем из заданного списка категорий
-            params[key] = trial.suggest_categorical(key, search_space[key])
+            raw_choices = search_space[key]
+            # Особая обработка для num_channels (списки списков)
+            if key == "num_channels":
+                # сериализуем списки в строки
+                choices_str = [str(lst) for lst in raw_choices]
+                # передаем строки в Optuna
+                sel = trial.suggest_categorical(key, tuple(choices_str))
+                # десериализуем обратно в список int
+                params[key] = ast.literal_eval(sel)
+            else:
+                # для остальных параметров — tuple из скаляров
+                choices = (
+                    tuple(raw_choices) if isinstance(raw_choices, list) else raw_choices
+                )
+                params[key] = trial.suggest_categorical(key, choices)
         else:
             params[key] = base_val
 
-    # Импорт и создание модели через фабрику
+    # Импорт модели и фильтрация параметров
     module_path = AVAILABLE.get(model_name)
     if not module_path:
         raise ValueError(f"Unknown model: {model_name}")
     module = import_module(module_path)
-    model = module.build_model(**params)
+    build_fn = module.build_model
+
+    # Оставляем только те параметры, которые принимает build_model
+    sig = inspect.signature(build_fn)
+    filtered_params = {k: v for k, v in params.items() if k in sig.parameters}
+
+    model = build_fn(**filtered_params)
     return model, lr
 
 
 def get_scheduler_if(opt_cfg: DictConfig, optimizer):
-    """
-    Возвращает ReduceLROnPlateau scheduler, если включен, иначе None.
-    """
     if opt_cfg.use_scheduler:
         return torch.optim.lr_scheduler.ReduceLROnPlateau(
             optimizer,
@@ -69,7 +90,9 @@ def evaluate(model: torch.nn.Module, dataloader, criterion, device):
     with torch.no_grad():
         for X, y in dataloader:
             X, y = X.to(device), y.to(device).squeeze(-1)
-            total_loss += criterion(model(X).squeeze(-1), y).item()
+            preds = model(X).squeeze(-1)
+            loss = criterion(preds, y)
+            total_loss += loss.item()
     return total_loss / len(dataloader)
 
 

--- a/app/transfer_learning.py
+++ b/app/transfer_learning.py
@@ -15,25 +15,24 @@ from app.data import fetch_cbr_usd_rate, fetch_moex_eod_data
 from app.preprocessing import preprocess_data
 
 
-def get_metadata_path(version: str = "v1"):
+def get_metadata_path():
+    # единый файл, куда мы всегда пишем/читаем последние метаданные
     metadata_dir = os.path.join("history", "metadata")
     os.makedirs(metadata_dir, exist_ok=True)
-    return os.path.join(metadata_dir, f"training_metadata_{version}.pkl")
+    return os.path.join(metadata_dir, "training_metadata.pkl")
 
 
-def load_training_metadata(version: str = None) -> dict:
-    # если version не указан, берём из ENV или по-умолчанию v1
-    version = version or os.getenv("MODEL_VERSION", "v1")
-    path = get_metadata_path(version)
+def load_training_metadata() -> dict:
+    # всегда читаем единый файл
+    path = get_metadata_path()
     if os.path.exists(path):
         with open(path, "rb") as f:
             return pickle.load(f)
     return {}
 
 
-def save_training_metadata(metadata: dict, version: str = None):
-    version = version or os.getenv("MODEL_VERSION", "v1")
-    path = get_metadata_path(version)
+def save_training_metadata(metadata: dict):
+    path = get_metadata_path()
     with open(path, "wb") as f:
         pickle.dump(metadata, f)
 
@@ -50,9 +49,8 @@ def retrain_model(
     default_epochs: int = 45,
     hpo_trials: int = 0,
 ) -> dict:
-    # определяем версию метаданных
-    version = cfg.train.version if cfg is not None else None
-    metadata = load_training_metadata(version)
+    # --- подготовка метаданных ---
+    metadata = load_training_metadata()
 
     # вытаскиваем из metadata или из текущего бандла
     factory_key = metadata.get(
@@ -87,7 +85,6 @@ def retrain_model(
             {"TRADEDATE": dates, "CLOSE": [fetch_cbr_usd_rate(d) for d in dates]}
         )
 
-    # нормализация и rename
     def prep(df, ren):
         df["TRADEDATE"] = pd.to_datetime(
             df.get("BEGIN", df["TRADEDATE"])
@@ -172,11 +169,13 @@ def retrain_model(
         mlflow.log_metric("retraining_loss", loss.item(), step=e)
 
     # сохраняем новую версию
-    maj, min_ = version.lstrip("v").split(".")
-    new_ver = f"v{maj}.{int(min_)+1}"
+    old_ver = metadata.get(f"{ticker}_model_version", "v1.0")
+    maj, min_ = old_ver.lstrip("v").split(".")
+    new_ver = f"v{maj}.{int(min_) + 1}"
     artifact_root = os.getenv("MODEL_ARTIFACTS_DIR", "saved_models")
     out_dir = os.path.join(artifact_root, new_ver)
     os.makedirs(out_dir, exist_ok=True)
+
     torch.save(model.state_dict(), os.path.join(out_dir, f"{ticker}_model.pth"))
     pickle.dump(scaler_X, open(os.path.join(out_dir, f"{ticker}_scaler_X.pkl"), "wb"))
     pickle.dump(scaler_y, open(os.path.join(out_dir, f"{ticker}_scaler_y.pkl"), "wb"))
@@ -186,9 +185,8 @@ def retrain_model(
     metadata[f"{ticker}_model_version"] = new_ver
     metadata[f"{ticker}_factory_key"] = factory_key
     metadata[f"{ticker}_model_params"] = model_params
-    save_training_metadata(metadata, new_ver)
+    save_training_metadata(metadata)
 
-    # возвращаем bundle
     return {
         "model": model,
         "scaler_X": scaler_X,

--- a/train.py
+++ b/train.py
@@ -70,7 +70,7 @@ def main(cfg: DictConfig):
 
     best_val = float("inf")
     for epoch in range(1, cfg.train.epochs + 1):
-        # train
+        # train loop
         model.train()
         train_loss = 0.0
         for X, y in train_dl:
@@ -84,7 +84,7 @@ def main(cfg: DictConfig):
             train_loss += loss.item()
         train_loss /= len(train_dl)
 
-        # val
+        # validation loop
         model.eval()
         val_loss = 0.0
         all_preds, all_targets = [], []
@@ -128,11 +128,19 @@ def main(cfg: DictConfig):
     with open(os.path.join(out_dir, f"{cfg.data.ticker}_scaler_y.pkl"), "wb") as fy:
         pickle.dump(scaler_y, fy)
 
-    # обновляем метаданные
-    md = load_training_metadata(cfg.train.version)
-    md[cfg.data.ticker] = cfg.data.start_date
-    md[f"{cfg.data.ticker}_params"] = cfg.model.params
-    save_training_metadata(md, cfg.train.version)
+    # --- обновляем единый файл training_metadata.pkl ---
+    md = load_training_metadata()
+    # дата последнего обучения — конец датасета
+    md[cfg.data.ticker] = cfg.data.end_date
+    # версия модели
+    md[f"{cfg.data.ticker}_model_version"] = cfg.train.version
+    # фабрика (lstm/tcn/…)
+    md[f"{cfg.data.ticker}_factory_key"] = cfg.model.name
+    # параметры модели (преобразуем в обычный dict)
+    md[f"{cfg.data.ticker}_model_params"] = OmegaConf.to_container(
+        cfg.model.params, resolve=True
+    )
+    save_training_metadata(md)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Changelog

### 🛠 Model management & Hydra integration
- After each Hydra‑driven training run, automatically:
  - Save new model artifacts (`.pth`, `*_scaler_X.pkl`, `*_scaler_y.pkl`) under `saved_models/v<MAJOR>.<MINOR>`.
  - Update and persist training metadata (`last_train_date`, `model_version`, `factory_key`, `model_params`) in `history/metadata/training_metadata_<version>.pkl`.
  - Load the correct versioned models in FastAPI via `app/model_manager.py`, logging all successfully loaded tickers and versions.
---